### PR TITLE
Fix the bswap_16 byte ordering macro fix.

### DIFF
--- a/artnet/private.h
+++ b/artnet/private.h
@@ -102,7 +102,7 @@ extern uint16_t HIGH_BYTE;
 // byte ordering macros
 #ifndef bswap_16
 #define bswap_16(x)  ((((x) >> 8) & 0xff) | (((x) & 0xff) << 8))
-#ifndef bswap_16
+#endif
 
 // htols : convert short from host to little endian order
 #ifdef WIN32


### PR DESCRIPTION
This was introduced by commit 3438164a5d9091eb5a6c682884e2cbf820ed3dfb
and seems to be some copy&paste error...