### PR TITLE
Fix edge cases in firmware send and receive related functions

### DIFF
--- a/artnet/receive.c
+++ b/artnet/receive.c
@@ -639,6 +639,11 @@ int handle_firmware(node n, artnet_packet p) {
 
     // length should be the remaining data
     block_length = n->firmware.bytes_total % (ARTNET_FIRMWARE_SIZE * sizeof(uint16_t));
+    if (block_length == 0) {
+      // remaining firmware size matches exactly maximum data size
+      block_length = ARTNET_FIRMWARE_SIZE * sizeof(uint16_t);
+      total_blocks--;
+    }
     block_id = p->data.firmware.blockId;
 
     // ok the blockid field is only 1 byte, so it wraps back to 0x00 we

--- a/artnet/receive.c
+++ b/artnet/receive.c
@@ -582,7 +582,7 @@ int handle_firmware(node n, artnet_packet p) {
           n->callbacks.firmware_c.fh(n,
                                      n->firmware.ubea,
                                      n->firmware.data,
-                                     n->firmware.bytes_total,
+                                     n->firmware.bytes_total / sizeof(p->data.firmware.data[0]),
                                      n->callbacks.firmware_c.data);
 
       } else {

--- a/artnet/transmit.c
+++ b/artnet/transmit.c
@@ -163,7 +163,7 @@ int artnet_tx_tod_data(node n, int id) {
   bloc = 0;
 
   while (remaining > 0) {
-    memset(&tod.data.toddata.tod,0x00, ARTNET_MAX_UID_COUNT);
+    memset(&tod.data.toddata.tod, 0x00, ARTNET_MAX_UID_COUNT * sizeof(tod.data.toddata.tod[0]));
     lim = min(ARTNET_MAX_UID_COUNT, remaining);
     tod.data.toddata.blockCount = bloc++;
     tod.data.toddata.uidCount = lim;

--- a/artnet/transmit.c
+++ b/artnet/transmit.c
@@ -272,7 +272,7 @@ int artnet_tx_firmware_reply(node n, in_addr_t ip,
 int artnet_tx_firmware_packet(node n, firmware_transfer_t *firm) {
   artnet_packet_t p;
   uint8_t type = 0;
-  int data_len, max_len, ret;
+  int data_len, max_len, remaining, ret;
 
   memset(&p, 0x0, sizeof(p));
 
@@ -282,6 +282,7 @@ int artnet_tx_firmware_packet(node n, firmware_transfer_t *firm) {
   // calculate length
   data_len = firm->bytes_total - firm->bytes_current;
   data_len = min(data_len, max_len);
+  remaining = firm->bytes_total - firm->bytes_current - data_len;
 
   // work out type - 6 cases
   if(firm->ubea) {
@@ -289,10 +290,10 @@ int artnet_tx_firmware_packet(node n, firmware_transfer_t *firm) {
     if (firm->bytes_current == 0) {
       // first
       type = ARTNET_FIRMWARE_UBEAFIRST;
-    } else if (data_len == max_len) {
+    } else if ((data_len == max_len) && (remaining > 0)) {
       // cont
       type = ARTNET_FIRMWARE_UBEACONT;
-    } else if (data_len < max_len) {
+    } else if ((data_len < max_len) || ((data_len == max_len) && (remaining == 0))) {
       // last
       type = ARTNET_FIRMWARE_UBEALAST;
     } else {
@@ -304,10 +305,10 @@ int artnet_tx_firmware_packet(node n, firmware_transfer_t *firm) {
     if (firm->bytes_current == 0) {
       // first
       type = ARTNET_FIRMWARE_FIRMFIRST;
-    } else if (data_len == max_len) {
+    } else if ((data_len == max_len) && (remaining > 0)) {
       // cont
       type = ARTNET_FIRMWARE_FIRMCONT;
-    } else if (data_len < max_len) {
+    } else if ((data_len < max_len) || ((data_len == max_len) && (remaining == 0))) {
       // last
       type = ARTNET_FIRMWARE_FIRMLAST;
     } else {


### PR DESCRIPTION
* fix callback handler receiving number of bytes instead of words when total firmware size <= 1024 bytes
* fix firmware send/receive block id/block length problem when firmware size is exactly a multiple of 1024 bytes
* fix transmit.c compile error