### PR TITLE
Added function to allow for unicasting to specific IP address

### DIFF
--- a/artnet/Makefile.am
+++ b/artnet/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -Wall -Werror -Wformat -W
+AM_CFLAGS = -I$(top_builddir) -I$(top_srcdir) -Wall -Wformat -W
 
 EXTRA_DIST = tod.h misc.h
 

--- a/artnet/artnet.c
+++ b/artnet/artnet.c
@@ -586,10 +586,9 @@ int artnet_send_poll_reply(artnet_node vn) {
   return artnet_tx_poll_reply(n, FALSE);
 }
 
-int artnet_send_dmx_to_addr(artnet_node vn, int port_id, int16_t length, const uint8_t *data, const char* address) {
+int artnet_send_dmx_to_addr(artnet_node vn, int port_id, int16_t length, const uint8_t *data, uint32_t address) {
   node n = vn;
   artnet_packet_t p;
-  int ret;
   input_port_t *port;
 
   check_nullnode(vn);
@@ -632,11 +631,10 @@ int artnet_send_dmx_to_addr(artnet_node vn, int port_id, int16_t length, const u
   p.data.admx.length = short_get_low_byte(length);
   memcpy(&p.data.admx.data, data, length);
 
-  p.to.s_addr = inet_addr(address);
+  p.to.s_addr = address;
   artnet_net_send(n, &p);
   return ARTNET_EOK;
 }
-
 
 /*
  * Sends some dmx data

--- a/artnet/artnet.h
+++ b/artnet/artnet.h
@@ -258,6 +258,11 @@ EXTERN int artnet_send_poll(artnet_node n,
   const char *ip,
   artnet_ttm_value_t talk_to_me);
 EXTERN int artnet_send_poll_reply(artnet_node n);
+EXTERN int artnet_send_dmx_to_addr(artnet_node n,
+int port_id,
+int16_t length,
+const uint8_t *data,
+const char* address);
 EXTERN int artnet_send_dmx(artnet_node n,
   int port_id,
   int16_t length,

--- a/artnet/artnet.h
+++ b/artnet/artnet.h
@@ -258,11 +258,8 @@ EXTERN int artnet_send_poll(artnet_node n,
   const char *ip,
   artnet_ttm_value_t talk_to_me);
 EXTERN int artnet_send_poll_reply(artnet_node n);
-EXTERN int artnet_send_dmx_to_addr(artnet_node n,
-int port_id,
-int16_t length,
-const uint8_t *data,
-const char* address);
+  EXTERN int artnet_send_dmx_to_addr(artnet_node n,
+    int port_id, int16_t length, const uint8_t *data, uint32_t address);
 EXTERN int artnet_send_dmx(artnet_node n,
   int port_id,
   int16_t length,

--- a/artnet/transmit.c
+++ b/artnet/transmit.c
@@ -163,7 +163,7 @@ int artnet_tx_tod_data(node n, int id) {
   bloc = 0;
 
   while (remaining > 0) {
-    memset(&tod.data.toddata.tod,0x00, ARTNET_MAX_UID_COUNT);
+    memset(&tod.data.toddata.tod,0x00, ARTNET_MAX_UID_COUNT * ARTNET_RDM_UID_WIDTH);
     lim = min(ARTNET_MAX_UID_COUNT, remaining);
     tod.data.toddata.blockCount = bloc++;
     tod.data.toddata.uidCount = lim;


### PR DESCRIPTION
Added function to artnet.c/.h that allows for sending artnet messages to a specific IP address. This function otherwise replicates ```artnet_send_dmx```, while stripping out unnecessary conditionals. The target IP address is provided as a uint32_t as the last argument to the new function. This value can be derived by using the ```inet_addr()``` function, as used elsewhere in libartnet and documented [here](https://pubs.opengroup.org/onlinepubs/009695399/functions/inet_addr.html).

```c
int artnet_send_dmx_to_addr(artnet_node vn, int port_id, int16_t length, const uint8_t *data, uint32_t address) {
  node n = vn;
  artnet_packet_t p;
  input_port_t *port;


  check_nullnode(vn);


  if (n->state.mode != ARTNET_ON) {
    return ARTNET_EACTION;
  }
  if (port_id < 0 || port_id >= ARTNET_MAX_PORTS) {
    artnet_error("%s : port index out of bounds (%i < 0 || %i > ARTNET_MAX_PORTS)", __FUNCTION__, port_id);
    return ARTNET_EARG;
  }
  port = &n->ports.in[port_id];


  if (length < 1 || length > ARTNET_DMX_LENGTH) {
    artnet_error("%s : Length of dmx data out of bounds (%i < 1 || %i > ARTNET_MAX_DMX)", __FUNCTION__, length);
    return ARTNET_EARG;
  }


  if (port->port_status & PORT_STATUS_DISABLED_MASK) {
    artnet_error("%s : attempt to send on a disabled port (id:%i)", __FUNCTION__, port_id);
    return ARTNET_EARG;
  }


  // ok we're going to send now, make sure we turn the activity bit on
  port->port_status = port->port_status | PORT_STATUS_ACT_MASK;


  p.length = sizeof(artnet_dmx_t) - (ARTNET_DMX_LENGTH - length);


  // now build packet
  memcpy(&p.data.admx.id, ARTNET_STRING, ARTNET_STRING_SIZE);
  p.data.admx.opCode =  htols(ARTNET_DMX);
  p.data.admx.verH = 0;
  p.data.admx.ver = ARTNET_VERSION;
  p.data.admx.sequence = port->seq;
  p.data.admx.physical = port_id;
  p.data.admx.universe = htols(port->port_addr);


  // set length
  p.data.admx.lengthHi = short_get_high_byte(length);
  p.data.admx.length = short_get_low_byte(length);
  memcpy(&p.data.admx.data, data, length);


  p.to.s_addr = address;
  artnet_net_send(n, &p);
  return ARTNET_EOK;
}
```